### PR TITLE
Add python 3.10 on ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  # triger 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter = jupyter_core.command:main


### PR DESCRIPTION
No changes.
Rebuild for python 3.10 support on ppc64le

The current state on ppc64le is:
https://repo.anaconda.com/pkgs/main/linux-ppc64le
jupyter_core-4.9.1-py37h6ffa863_0.tar.bz2
jupyter_core-4.9.1-py38h6ffa863_0.tar.bz2
jupyter_core-4.9.1-py39h6ffa863_0.tar.bz2