### PR TITLE
jupyter_core 4.9.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  # triger 1
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter = jupyter_core.command:main
@@ -30,19 +30,20 @@ requirements:
     - pywin32 >=1.0  # [win]
     - traitlets
 
-{% set skip = "not test_not_on_path and not test_path_priority" %}
+{% set skip = ["test_not_on_path", "test_path_priority"] %}
+# linux shebang lines have a length limit longer than the placeholder test prefix
+{% set skip = skip + ["test_argv0"] %}  # [linux]
+{% set skip = '-k "not (' + (skip | join(' or ')) + ')"' %}
 test:
   requires:
-    # - ipykernel
-    - nose
     - pytest
     - pip
   commands:
+    - pip check
     - jupyter -h
     - jupyter-migrate -h
     - jupyter-troubleshoot --help
-    - python -m pytest --pyargs jupyter_core -k "{{ skip }}"
-    - pip check
+    - python -m pytest -vv --pyargs jupyter_core {{ skip }}
   imports:
     - jupyter_core
     - jupyter_core.utils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.9.1" %}
-{% set sha256 = "dce8a7499da5a53ae3afd5a9f4b02e5df1d57250cf48f3ad79da23b4778cd6fa" %}
+{% set version = "4.9.2" %}
+{% set sha256 = "d69baeb9ffb128b8cd2657fcf2703f89c769d1673c851812119e3a2a0e93ad9a" %}
 
 package:
   name: jupyter_core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ requirements:
 
 {% set skip = ["test_not_on_path", "test_path_priority"] %}
 # linux shebang lines have a length limit longer than the placeholder test prefix
-{% set skip = skip + ["test_argv0"] %}  # [linux]
+{% set skip = skip + ["test_argv0"] %}  # [linux or (win and py==310)]
+{% set skip = skip + ["tesTESTS"] %}  # [win and py==310]
 {% set skip = '-k "not (' + (skip | join(' or ')) + ')"' %}
 test:
   requires:


### PR DESCRIPTION
Update jupyter_core to 4.9.2

Version change: bump version number from 4.9.1 to 4.9.2
Bug Tracker: new open issues https://github.com/jupyter/jupyter_core/issues
Github releases:  https://github.com/jupyter/jupyter_core/releases
Upstream setup file: https://github.com/jupyter/jupyter_core/blob/4.9.2/setup.cfg

The package jupyter_core is mentioned inside the packages:
jupyter_client | jupyter_kernel_gateway | jupyterlab | jupyter_server | nbconvert | nbformat | notebook | qtconsole |

Actions:
1. Skip py<36, https://github.com/jupyter/jupyter_core/blob/33d0f94244b26ad1fa7a84cea3007e9ce7a3d8af/setup.cfg#L25
2. Update tests for skipping