### PR TITLE
Update `Jupyter_Core` to  version `4.11.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.10.0" %}
-{% set sha256 = "a6de44b16b7b31d7271130c71a6792c4040f077011961138afed5e5e73181aec" %}
+{% set version = "4.11.1" %}
+{% set sha256 = "2e5f244d44894c4154d06aeae3419dd7f1b0ef4494dc5584929b398c61cfd314" %}
 
 package:
   name: jupyter_core
@@ -19,11 +19,14 @@ build:
     - jupyter-troubleshoot = jupyter_core.troubleshoot:main
 
 requirements:
+  build:
+    - python
   host:
     - pip
     - python
     - setuptools >=60.0
     - wheel
+    - hatchling >=1.4
   run:
     - python
     - pywin32 >=1.0  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,9 @@ build:
     - jupyter-troubleshoot = jupyter_core.troubleshoot:main
 
 requirements:
-  build:
-    - python
   host:
     - pip
     - python
-    - setuptools >=60.0
-    - wheel
     - hatchling >=1.4
   run:
     - python


### PR DESCRIPTION
`jupyter_core` version `4.11.1`
1. - [x] Check the upstream
    https://github.com/jupyter/jupyter_core/tree/4.11.1

2. - [x] Check the pinnings
    
    The pinnings on the package were reviewed

3. - [x] Check the changelogs
    https://github.com/jupyter/jupyter_core/blob/4.11.1/docs/changelog.rst

    The package does not have significant breaking changes mentioned in the `Changelog`

4. - [x] Additional research
    https://github.com/conda-forge/jupyter_core-feedstock/issues

    There are nno significant open issues metioned at the time of the review.

5. - [x] Verify the `dev_url`
    https://github.com/jupyter/jupyter_core

6. - [x] Verify the `doc_url`
    https://jupyter-core.readthedocs.io

7. - [x] License is `spdx` compliant
    BSD-3-Clause
8. - [x] License family is present
    BSD
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`

11. - [x] Verify if the package needs `wheel`

12. - [x] `pip` in the test section
    pip
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `jupyter_core` to version `4.11.1`
