### PR TITLE
jupyter_core 4.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ about:
     This package contains base application classes and configuration inherited by other projects.
   dev_url: https://github.com/jupyter/jupyter_core
   doc_url: https://jupyter-core.readthedocs.io
-  doc_source_url: https://github.com/jupyter/jupyter_core/tree/master/docs
+  doc_source_url: https://github.com/jupyter/jupyter_core/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
+{% set name = "jupyter_core" %}
 {% set version = "4.11.2" %}
-{% set sha256 = "c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337" %}
 
 package:
-  name: jupyter_core
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jupyter_core/jupyter_core-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337
 
 build:
   number: 0
@@ -23,6 +23,7 @@ requirements:
     - pip
     - python
     - hatchling >=1.4
+    - wheel
   run:
     - python
     - pywin32 >=1.0  # [win]
@@ -53,7 +54,11 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: COPYING.md
+  license_url: https://github.com/jupyter/jupyter_core/blob/main/COPYING.md
   summary: Core common functionality of Jupyter projects.
+  description: |
+    Jupyter core package. A base package on which Jupyter projects rely.
+    This package contains base application classes and configuration inherited by other projects.
   dev_url: https://github.com/jupyter/jupyter_core
   doc_url: https://jupyter-core.readthedocs.io
   doc_source_url: https://github.com/jupyter/jupyter_core/tree/master/docs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: COPYING.md
-  license_url: https://github.com/jupyter/jupyter_core/blob/main/COPYING.md
   summary: Core common functionality of Jupyter projects.
   description: |
     Jupyter core package. A base package on which Jupyter projects rely.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
   host:
     - pip
     - python
-    - hatchling >=1.4
+    - hatchling
+    - setuptools
     - wheel
   run:
     - python
@@ -60,7 +61,6 @@ about:
     This package contains base application classes and configuration inherited by other projects.
   dev_url: https://github.com/jupyter/jupyter_core
   doc_url: https://jupyter-core.readthedocs.io
-  doc_source_url: https://github.com/jupyter/jupyter_core/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.11.1" %}
-{% set sha256 = "2e5f244d44894c4154d06aeae3419dd7f1b0ef4494dc5584929b398c61cfd314" %}
+{% set version = "4.11.2" %}
+{% set sha256 = "c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337" %}
 
 package:
   name: jupyter_core


### PR DESCRIPTION
**Jira ticket:** [PKG-664](https://anaconda.atlassian.net/browse/PKG-664) (jupyter_core-4.11.2)

**The upstream data:**
Github releases:  https://github.com/jupyter/jupyter_core/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/jupyter_core/compare/4.10.0...4.11.2)
Requirements:
 * pyproject.toml:  https://github.com/jupyter/jupyter_core/blob/4.11.2/pyproject.toml

**_Actions:_**

1. Add `wheel`, `setuptools` to `host`
2. Remove `hatchling` pinning
2. Add a `description`

**_Notes:_**
 * Addressing CVE-2022-39286

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 4.11.2
 * Release on PyPi:
    * version: 4.11.2
    * date: 2022-10-19T14:11:36
* [PyPi history](https://pypi.org/project/jupyter_core/#history)
 * Popularity: 
    * 3 months downloads: 2426839.0
    * All time:  13437141 downloads -  jupyter_core  4.11.2  Core common functionality of Jupyter projects.  

</details>

**Links:**
<details>

* [The v4.11.2 upstream URL](https://github.com/jupyter/jupyter_core/tree/4.11.2)
* [Bug tracker](https://github.com/jupyter/jupyter_core/issues)
* [PyPi](https://pypi.org/project/jupyter_core)
* [conda-forge recipe](https://github.com/conda-forge/jupyter_core-feedstock/blob/master/recipe/meta.yaml)
* [Anaconda recipe feedstock](https://github.com/AnacondaRecipes/jupyter_core-feedstock)
* [Update branch: _4.11.2_](https://github.com/AnacondaRecipes/jupyter_core-feedstock/tree/4.11.2)
* [Diff between upstream conda-forge **main** and aggregate **feature** branch](https://github.com/conda-forge/jupyter_core-feedstock/compare/main...AnacondaRecipes:4.11.2#files_bucket)
* [Diff between origin aggregate **master** and aggregate **feature** branch](https://github.com/AnacondaRecipes/jupyter_core-feedstock/compare/master...AnacondaRecipes:4.11.2#files_bucket)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyter_core-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyter/jupyter_core/tree/4.11.2 exists
5. - [x] https://jupyter.org is present
6. - [x] Check the pinnings
7. - [x] Additional research
    https://github.com/jupyter/jupyter_core/issues
    200
8. - [x] `dev_url` is present
    https://github.com/jupyter/jupyter_core
9. - [x] `doc_url` error:
    https://jupyter-core.readthedocs.io
    302
7. - [x] `doc_source_url`:
    https://github.com/jupyter/jupyter_core/tree/main/docs
10. - [x] Verify that the `build_number` is correct
11. - [x] has `setuptools`
12. - [x] has `wheel`
13. - [x] `pip` in test
14. - [x] Verify the test section
15. - [x] Verify if the package is `architecture specific`
16. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
17.  - [x] license_file: COPYING.md is present
18. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

19. - [x] license_family BSD is present
</details>


**Updating the recipe:**

If the recipe needs additional modification the update branch can be modified.

```
git clone -b 4.11.2 git@github.com:AnacondaRecipes/jupyter_core-feedstock.git
```

