### PR TITLE
jupyter_core updated to version 5.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_core" %}
-{% set version = "4.11.2" %}
+{% set version = "5.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337
+  sha256: 4ed68b7c606197c7e344a24b7195eef57898157075a69655a886074b6beb7043 
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter = jupyter_core.command:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ test:
   requires:
     - pytest
     - pip
+    - platformdirs
   commands:
     - pip check
     - jupyter -h


### PR DESCRIPTION
## jupyter_core version updated from 4.11.2 -> 5.0.0
upstream: https://github.com/jupyter/jupyter_core
change log: https://github.com/jupyter/jupyter_core/blob/main/CHANGELOG.md

## Changes
- bumped version number
- changed SHA
- added test dependency due to test failures
- updated required python version from `3.7` to `3.8`