### PR TITLE
jupyter_core updated to version 5.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_core" %}
-{% set version = "4.11.2" %}
+{% set version = "5.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337
+  sha256: a5ae7c09c55c0b26f692ec69323ba2b62e8d7295354d20f6cd57b749de4a05bf
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - python
     - pywin32 >=1.0  # [win]
     - traitlets
+    - platformdirs
 
 {% set skip = ["test_not_on_path", "test_path_priority"] %}
 # linux shebang lines have a length limit longer than the placeholder test prefix

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter = jupyter_core.command:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
   run:
     - python
     - pywin32 >=1.0  # [win]
-    - traitlets
-    - platformdirs
+    - traitlets >=5.3
+    - platformdirs >=2.5
 
 {% set skip = ["test_not_on_path", "test_path_priority"] %}
 # linux shebang lines have a length limit longer than the placeholder test prefix


### PR DESCRIPTION
## jupyter_core version updated from 4.11.2 -> 5.1.0
upstream: https://github.com/jupyter/jupyter_core
change log: https://github.com/jupyter/jupyter_core/blob/main/CHANGELOG.md

## Changes
- bumped version number
- changed SHA
- added required run dependency 
   (https://github.com/jupyter/jupyter_core/blob/v5.0.0/pyproject.toml#L20)
- updated required python version from `3.7` to `3.8` 
   (https://github.com/jupyter/jupyter_core/blob/00ed92e136c9b6f84778a5e94f934f0efbe16c42/pyproject.toml#L18)
- adding pinning requirements
  (https://github.com/jupyter/jupyter_core/blob/00ed92e136c9b6f84778a5e94f934f0efbe16c42/pyproject.toml#L20-L21)