### PR TITLE
jupyter_core update to v 5.3.0:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_core" %}
-{% set version = "5.2.0" %}
+{% set version = "5.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f
+  sha256: 6db75be0c83edbf1b7c9f91ec266a9a24ef945da630f3120e1a0046dc13713fc
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter = jupyter_core.command:main
@@ -27,11 +27,14 @@ requirements:
     - wheel
   run:
     - python
-    - pywin32 >=1.0  # [win]
+    - pywin32 >=300  # [win]
     - traitlets >=5.3
     - platformdirs >=2.5
 
 {% set skip = ["test_not_on_path", "test_path_priority"] %}
+# The following 2 tests were poorly setup following the breaking change in platformdirs 3.0.0. 
+# Can activate these tests once we have platformdir >3.0.0  
+{% set skip = skip + ["test_config_dir", "test_runtime_dir"] %}  # [osx]
 # linux shebang lines have a length limit longer than the placeholder test prefix
 {% set skip = skip + ["test_argv0"] %}  # [linux or (win and py==310)]
 {% set skip = skip + ["tesTESTS"] %}  # [win and py==310]
@@ -55,7 +58,7 @@ about:
   home: https://jupyter.org
   license: BSD-3-Clause
   license_family: BSD
-  license_file: COPYING.md
+  license_file: LICENSE
   summary: Core common functionality of Jupyter projects.
   description: |
     Jupyter core package. A base package on which Jupyter projects rely.


### PR DESCRIPTION
- version bumped up and sha256 updated
- update dependency range
- update license_file
- switch off two poorly configured tests that fail on osx
